### PR TITLE
Updates to test_intervals restrictions and evaluate method

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -166,7 +166,7 @@ survival_modeler = LGBSurvivalModeler(config={'PATIENCE': 8},
 survival_modeler.build_model()
 ```
 
-The `evaluate` method offers a suite of performance metrics specific to each time horizon as well as the concordance index over the restricted mean survival time. See the description of [Metrics.csv](cli_link.html#metrics-csv) above for more details. We can pass a Boolean mask to `evaluate` to obtain metrics only for the period we pretended was the most recent period. Be careful to not set test intervals to be too large-- if it exceeds half of the number of periods, it will not provide the training dataset with enough periods.
+The `evaluate` method offers a suite of performance metrics specific to each time horizon as well as the concordance index over the restricted mean survival time. See the description of [Metrics.csv](cli_link.html#metrics-csv) above for more details. We can pass a Boolean mask to `evaluate` to obtain metrics only for the period we pretended was the most recent period. Be careful to not set `TEST_INTERVALS` to be too large; if it exceeds half of the number of intervals, it will not provide the training dataset with enough intervals.
 
 ```python
 evaluation_subset = survival_modeler.data["_period"] == (

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -166,7 +166,7 @@ survival_modeler = LGBSurvivalModeler(config={'PATIENCE': 8},
 survival_modeler.build_model()
 ```
 
-The `evaluate` method offers a suite of performance metrics specific to each time horizon as well as the concordance index over the restricted mean survival time. See the description of [Metrics.csv](cli_link.html#metrics-csv) above for more details. We can pass a Boolean mask to `evaluate` to obtain metrics only for the period we pretended was the most recent period.
+The `evaluate` method offers a suite of performance metrics specific to each time horizon as well as the concordance index over the restricted mean survival time. See the description of [Metrics.csv](cli_link.html#metrics-csv) above for more details. We can pass a Boolean mask to `evaluate` to obtain metrics only for the period we pretended was the most recent period. Be careful to not set test intervals to be too large-- if it exceeds half of the number of periods, it will not provide the training dataset with enough periods.
 
 ```python
 evaluation_subset = survival_modeler.data["_period"] == (

--- a/fife/__main__.py
+++ b/fife/__main__.py
@@ -78,7 +78,7 @@ def main():
     if test_intervals > 0:
 
         # Save metrics
-        max_test_intervals = len(set(modeler.data["_period"])) / 2 - 1
+        max_test_intervals = (len(set(modeler.data["_period"])) - 1) / 2
 
         evaluation_subset = modeler.data["_period"] == (
             modeler.data["_period"].max() - min(test_intervals, max_test_intervals)

--- a/fife/__main__.py
+++ b/fife/__main__.py
@@ -74,11 +74,14 @@ def main():
     print(f"Model training time: {time() - checkpoint_time} seconds")
 
     checkpoint_time = time()
+
     if test_intervals > 0:
 
         # Save metrics
+        max_test_intervals = len(set(modeler.data["_period"])) / 2 - 1
+
         evaluation_subset = modeler.data["_period"] == (
-            modeler.data["_period"].max() - test_intervals
+            modeler.data["_period"].max() - min(test_intervals, max_test_intervals)
         )
         utils.save_output_table(
             modeler.evaluate(evaluation_subset),

--- a/fife/base_modelers.py
+++ b/fife/base_modelers.py
@@ -398,6 +398,7 @@ class SurvivalModeler(Modeler):
             self.data[subset][self.event_col],
         )
         metrics["C-Index"] = np.where(metrics.index == 1, concordance_index_value, "")
+        metrics = metrics.dropna()
         return metrics
 
     def forecast(self) -> pd.core.frame.DataFrame:

--- a/fife/processors.py
+++ b/fife/processors.py
@@ -333,9 +333,9 @@ class PanelDataProcessor(DataProcessor):
             "TEST_INTERVALS", self.config.get("TEST_PERIODS", 0) - 1
         )
 
-        if self.config.get("TEST_INTERVALS", -1) > max_test_intervals:
+        if test_intervals > max_test_intervals:
             warn(
-                f"The specified value for TEST_INTERVALS of {test_intervals} was too high. It was automatically reduced to {max_test_intervals}"
+                f"The specified value for TEST_INTERVALS of {test_intervals} was too high and will not allow for enough training periods. It was automatically reduced to {max_test_intervals}"
             )
             test_intervals = max_test_intervals
 

--- a/fife/processors.py
+++ b/fife/processors.py
@@ -327,10 +327,21 @@ class PanelDataProcessor(DataProcessor):
             self.data[self.config["TIME_IDENTIFIER"]], sort=True
         )[0]
         self.data["_predict_obs"] = self.data["_period"] == self.data["_period"].max()
-        self.data["_test"] = (
-            self.data["_period"]
-            + self.config.get("TEST_INTERVALS", self.config.get("TEST_PERIODS", 0) - 1)
-        ) >= self.data["_period"].max()
+
+        max_test_intervals = len(set(self.data["_period"])) / 2 - 1
+        test_intervals = self.config.get(
+            "TEST_INTERVALS", self.config.get("TEST_PERIODS", 0) - 1
+        )
+
+        if self.config.get("TEST_INTERVALS", -1) > max_test_intervals:
+            warn(
+                f"The specified value for TEST_INTERVALS of {test_intervals} was too high. It was automatically reduced to {max_test_intervals}"
+            )
+            test_intervals = max_test_intervals
+
+        self.data["_test"] = (self.data["_period"] + test_intervals) >= self.data[
+            "_period"
+        ].max()
         self.data["_validation"] = (
             self.flag_validation_individuals() & ~self.data["_test"]
         )

--- a/fife/processors.py
+++ b/fife/processors.py
@@ -328,7 +328,7 @@ class PanelDataProcessor(DataProcessor):
         )[0]
         self.data["_predict_obs"] = self.data["_period"] == self.data["_period"].max()
 
-        max_test_intervals = len(set(self.data["_period"])) / 2 - 1
+        max_test_intervals = (len(set(self.data["_period"])) - 1) / 2
         test_intervals = self.config.get(
             "TEST_INTERVALS", self.config.get("TEST_PERIODS", 0) - 1
         )


### PR DESCRIPTION
- Removed NAs from model.evaluate() in base_modelers.py
- Imposed restriction on test_intervals in processors.py
- Ensured that evaluation subset prints correctly depending on a modified test_intervals in __main__.py