### PR TITLE
ExitModeler exit type values correction

### DIFF
--- a/fife/base_modelers.py
+++ b/fife/base_modelers.py
@@ -728,9 +728,7 @@ class StateModeler(Modeler):
                 ],
                 forecasts.shape[0],
             )
-            states = np.tile(
-                self.class_values, forecasts.shape[1]
-            )
+            states = np.tile(self.class_values, forecasts.shape[1])
             forecasts = np.reshape(
                 forecasts,
                 (forecasts.shape[0] * forecasts.shape[1], forecasts.shape[2]),
@@ -795,7 +793,9 @@ class ExitModeler(StateModeler):
             **kwargs: Arguments to Modeler.__init__().
         """
         super().__init__(exit_col, **kwargs)
-        self.class_values = self.data[(self.data['_duration']==0) & (self.data['_event_observed']==True)][self.state_col].unique()
+        self.class_values = self.data[
+            (self.data["_duration"] == 0) & (self.data["_event_observed"] == True)
+        ][self.state_col].unique()
         self.num_class = len(self.class_values)
         self.exit_col = self.state_col
         if self.data is not None:

--- a/fife/base_modelers.py
+++ b/fife/base_modelers.py
@@ -652,7 +652,8 @@ class StateModeler(Modeler):
         if self.data is not None:
             if self.state_col in self.categorical_features:
                 self.objective = "multiclass"
-                self.num_class = len(self.data[self.state_col].cat.categories)
+                self.class_values = self.data[self.state_col].cat.categories
+                self.num_class = len(self.class_values)
             elif self.state_col in self.numeric_features:
                 self.objective = "regression"
                 self.num_class = None
@@ -727,7 +728,7 @@ class StateModeler(Modeler):
                 forecasts.shape[0],
             )
             states = np.tile(
-                self.data[self.state_col].cat.categories, forecasts.shape[1]
+                self.class_values, forecasts.shape[1]
             )
             forecasts = np.reshape(
                 forecasts,
@@ -793,6 +794,8 @@ class ExitModeler(StateModeler):
             **kwargs: Arguments to Modeler.__init__().
         """
         super().__init__(exit_col, **kwargs)
+        self.class_values = self.data[(self.data['_duration']==0) & (self.data['_event_observed']==True)][self.state_col].unique()
+        self.num_class = len(self.class_values)
         self.exit_col = self.state_col
         if self.data is not None:
             if self.state_col in self.categorical_features:

--- a/fife/base_modelers.py
+++ b/fife/base_modelers.py
@@ -636,6 +636,7 @@ class StateModeler(Modeler):
         objective (str): The model objective appropriate for the outcome type;
             "multiclass" for categorical states and "regression" for numeric
             states.
+        class_values (pd.Int64Index): The state categories.
         num_class (int): The number of state categories or, if the state is
             numeric, None.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ cycler==0.10.0
 cytoolz==0.11.0
 dask @ file:///home/conda/feedstock_root/build_artifacts/dask-core_1607657054678/work
 decorator==4.4.2
-fife @ file:///C:/Users/jbishop/Desktop/fife/dist/fife-1.4.1-py3-none-any.whl
+fife @ file:///C:/Users/JBishop/Desktop/fife/dist/fife-1.4.1-py3-none-any.whl
 future==0.18.2
 gast==0.2.2
 google-auth @ file:///tmp/build/80754af9/google-auth_1600960338579/work
@@ -118,7 +118,7 @@ toolz @ file:///home/conda/feedstock_root/build_artifacts/toolz_1600973991856/wo
 tornado @ file:///D:/bld/tornado_1604105307492/work
 tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1608900042843/work
 traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1602771532708/work
-typed-ast==1.4.1
+typed-ast==1.4.2
 typing-extensions==3.7.4.3
 urllib3 @ file:///home/conda/feedstock_root/build_artifacts/urllib3_1605225765842/work
 wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1600965781394/work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 absl-py @ file:///C:/ci/absl-py_1600290345082/work
+aiohttp @ file:///C:/ci/aiohttp_1602530358780/work
 alembic==1.4.3
-appdirs @ file:///home/conda/feedstock_root/build_artifacts/appdirs_1603108395799/work
+appdirs==1.4.4
 astor==0.8.1
+async-timeout==3.0.1
 atomicwrites==1.4.0
-attrs==20.3.0
+attrs @ file:///tmp/build/80754af9/attrs_1600298409949/work
 autograd==1.3
 autograd-gamma==0.5.0
 backcall @ file:///home/conda/feedstock_root/build_artifacts/backcall_1592338393461/work
@@ -13,8 +15,8 @@ blinker==1.4
 brotlipy==0.7.0
 cachetools @ file:///tmp/build/80754af9/cachetools_1596822027882/work
 certifi==2020.6.20
-cffi @ file:///D:/bld/cffi_1606601427219/work
-chardet @ file:///D:/bld/chardet_1607673976135/work
+cffi @ file:///C:/ci/cffi_1600699250966/work
+chardet==3.0.4
 click==7.1.2
 cliff==3.5.0
 cloudpickle @ file:///home/conda/feedstock_root/build_artifacts/cloudpickle_1598400192773/work
@@ -22,7 +24,7 @@ cmaes==0.7.0
 cmd2==1.4.0
 colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1602866480661/work
 colorlog==4.6.2
-cryptography @ file:///D:/bld/cryptography_1607606333800/work
+cryptography @ file:///C:/ci/cryptography_1601046913206/work
 cycler==0.10.0
 cytoolz==0.11.0
 dask @ file:///home/conda/feedstock_root/build_artifacts/dask-core_1607657054678/work
@@ -30,13 +32,12 @@ decorator==4.4.2
 fife @ file:///C:/Users/JBishop/Desktop/fife/dist/fife-1.4.1-py3-none-any.whl
 future==0.18.2
 gast==0.2.2
-google-auth @ file:///tmp/build/80754af9/google-auth_1600960338579/work
+google-auth @ file:///tmp/build/80754af9/google-auth_1601995530934/work
 google-auth-oauthlib==0.4.1
 google-pasta==0.2.0
 grpcio @ file:///C:/ci/grpcio_1597406403308/work
 h5py==2.8.0
-idna @ file:///home/conda/feedstock_root/build_artifacts/idna_1593328102638/work
-imagecodecs @ file:///D:/bld/imagecodecs_1609353636513/work
+idna @ file:///tmp/build/80754af9/idna_1593446292537/work
 imageio @ file:///home/conda/feedstock_root/build_artifacts/imageio_1594044661732/work
 importlib-metadata @ file:///tmp/build/80754af9/importlib-metadata_1602276842396/work
 iniconfig @ file:///home/conda/feedstock_root/build_artifacts/iniconfig_1603384189793/work
@@ -55,38 +56,38 @@ Mako==1.1.3
 Markdown @ file:///C:/ci/markdown_1603216569530/work
 MarkupSafe==1.1.1
 matplotlib @ file:///D:/bld/matplotlib-suite_1605180495775/work
+multidict @ file:///C:/ci/multidict_1600456486794/work
 mypy-extensions==0.4.3
 networkx @ file:///home/conda/feedstock_root/build_artifacts/networkx_1598210780226/work
 numba @ file:///D:/bld/numba_1607010622162/work
-numpy @ file:///D:/bld/numpy_1604946150193/work
+numpy @ file:///D:/bld/numpy_1609881245947/work
 oauthlib==3.1.0
 olefile @ file:///home/conda/feedstock_root/build_artifacts/olefile_1602866521163/work
 opt-einsum==3.1.0
 optuna==2.3.0
-packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1607785313469/work
+packaging==20.8
 pandas @ file:///D:/bld/pandas_1609079442779/work
 parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1607618318316/work
 pathspec==0.8.1
 patsy==0.5.1
 pbr==5.5.1
 pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1602536217715/work
-Pillow @ file:///D:/bld/pillow_1604748899638/work
+Pillow @ file:///D:/bld/pillow_1609628021887/work
 pluggy==0.13.1
-pooch @ file:///home/conda/feedstock_root/build_artifacts/pooch_1606467285986/work
 prettytable==0.7.2
-prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1605053337398/work
+prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1609920610344/work
 protobuf==3.13.0
 py==1.10.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pycparser @ file:///home/conda/feedstock_root/build_artifacts/pycparser_1593275161868/work
+pycparser @ file:///tmp/build/80754af9/pycparser_1594388511720/work
 Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1607352093725/work
 PyJWT==1.7.1
-pyOpenSSL @ file:///home/conda/feedstock_root/build_artifacts/pyopenssl_1608055815057/work
+pyOpenSSL @ file:///tmp/build/80754af9/pyopenssl_1594392929924/work
 pyparsing==2.4.7
 pyperclip==1.8.1
 pyreadline==2.1
-PySocks @ file:///D:/bld/pysocks_1602327025506/work
+PySocks @ file:///C:/ci/pysocks_1594394709107/work
 pytest==6.2.1
 python-dateutil==2.8.1
 python-editor==1.0.4
@@ -94,10 +95,10 @@ pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1608904108784/work
 PyWavelets @ file:///D:/bld/pywavelets_1607290963729/work
 PyYAML==5.3.1
 regex==2020.11.13
-requests @ file:///home/conda/feedstock_root/build_artifacts/requests_1608156231189/work
+requests @ file:///tmp/build/80754af9/requests_1592841827918/work
 requests-oauthlib==1.3.0
 rsa @ file:///tmp/build/80754af9/rsa_1596998415516/work
-scikit-image==0.18.1
+scikit-image==0.16.2
 scikit-learn @ file:///D:/bld/scikit-learn_1608656375159/work
 scipy==1.4.1
 seaborn==0.11.1
@@ -112,18 +113,18 @@ tensorflow==2.1.0
 tensorflow-estimator==2.1.0
 termcolor==1.1.0
 threadpoolctl @ file:///tmp/tmp79xdzxkt/threadpoolctl-2.1.0-py3-none-any.whl
-tifffile @ file:///home/conda/feedstock_root/build_artifacts/tifffile_1607552325200/work
 toml==0.10.2
 toolz @ file:///home/conda/feedstock_root/build_artifacts/toolz_1600973991856/work
 tornado @ file:///D:/bld/tornado_1604105307492/work
-tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1608900042843/work
+tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1609612933698/work
 traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1602771532708/work
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3 @ file:///home/conda/feedstock_root/build_artifacts/urllib3_1605225765842/work
+urllib3 @ file:///tmp/build/80754af9/urllib3_1603305693037/work
 wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1600965781394/work
 Werkzeug==0.16.1
-win-inet-pton @ file:///D:/bld/win_inet_pton_1602260090416/work
+win-inet-pton==1.1.0
 wincertstore==0.2
 wrapt==1.12.1
+yarl @ file:///C:/ci/yarl_1602679793616/work
 zipp @ file:///tmp/build/80754af9/zipp_1603306325174/work


### PR DESCRIPTION
ExitModeler initialization now sets self.class_values and self.num_class to be based on the unique values of exit from exit_col, excluding values corresponding to censoring.  This overrides the values set by StateModeler so as to not affect uses outside of ExitModeler.  (StateModeler initialization also now sets self.class_values, but does so based on the previous method in order to not potentially interfere with other functionality.)