### PR TITLE
Updated requirements.txt generation to only include version numbers

### DIFF
--- a/build_package.bat
+++ b/build_package.bat
@@ -27,7 +27,7 @@ if '!errorlevel!' == '0' (
 		if '!errorlevel!' == '0' (
 			fife --TREE_MODELS False
 			if '!errorlevel!' == '0' (
-				pip freeze > requirements.txt
+				pip list --format=freeze > requirements.txt
 				color 0A
 				echo "Tests passed."
 			) else (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,118 +1,122 @@
-absl-py==0.12.0
-alembic==1.5.8
-appdirs==1.4.4
+absl-py==1.0.0
+alembic==1.7.6
 astor==0.8.1
+asttokens==2.0.5
 astunparse==1.6.3
 atomicwrites==1.4.0
-attrs==20.3.0
+attrs==21.4.0
 autograd==1.3
 autograd-gamma==0.5.0
-backcall @ file:///home/conda/feedstock_root/build_artifacts/backcall_1592338393461/work
-backports.functools-lru-cache==1.6.1
-black==20.8b1
-cachetools==4.2.1
-certifi==2020.12.5
-chardet==4.0.0
-click==7.1.2
-cliff==3.7.0
-cloudpickle @ file:///home/conda/feedstock_root/build_artifacts/cloudpickle_1598400192773/work
+autopage==0.5.0
+backcall==0.2.0
+black==22.1.0
+cachetools==5.0.0
+certifi==2021.10.8
+charset-normalizer==2.0.12
+click==8.0.3
+cliff==3.10.0
+cloudpickle==2.0.0
 cmaes==0.8.2
-cmd2==1.5.0
-colorama @ file:///home/conda/feedstock_root/build_artifacts/colorama_1602866480661/work
-colorlog==4.8.0
-cycler==0.10.0
-cytoolz==0.11.0
-dask @ file:///home/conda/feedstock_root/build_artifacts/dask-core_1614995065708/work
-decorator==4.4.2
-fife @ file:///C:/Users/JBishop/Desktop/fife/dist/fife-1.5.1-py3-none-any.whl
-flatbuffers==1.12
-formulaic==0.2.3
+cmd2==2.3.3
+colorama==0.4.4
+colorlog==6.6.0
+cycler==0.11.0
+dask==2022.2.0
+decorator==5.1.1
+executing==0.8.2
+fife==1.5.1
+flatbuffers==2.0
+fonttools==4.29.1
+formulaic==0.2.4
+fsspec==2022.1.0
 future==0.18.2
-gast==0.3.3
-google-auth==1.28.0
-google-auth-oauthlib==0.4.3
+gast==0.5.3
+google-auth==2.6.0
+google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
-greenlet==1.0.0
-grpcio==1.32.0
-h5py==2.10.0
-idna==2.10
-imageio @ file:///home/conda/feedstock_root/build_artifacts/imageio_1594044661732/work
-iniconfig @ file:///home/conda/feedstock_root/build_artifacts/iniconfig_1603384189793/work
-interface-meta==1.2.3
-ipython @ file:///D:/bld/ipython_1614393744923/work
-ipython-genutils==0.2.0
-jedi @ file:///D:/bld/jedi_1610146948662/work
-joblib @ file:///home/conda/feedstock_root/build_artifacts/joblib_1612898609989/work
-Keras==2.4.3
+greenlet==1.1.2
+grpcio==1.43.0
+h5py==3.6.0
+idna==3.3
+iniconfig==1.1.1
+interface-meta==1.2.4
+ipython==8.0.1
+jedi==0.18.1
+joblib==1.1.0
+keras==2.8.0
 Keras-Preprocessing==1.1.2
-kiwisolver @ file:///D:/bld/kiwisolver_1610099948875/work
-lifelines==0.25.10
-lightgbm==3.2.0
-llvmlite==0.36.0
-Mako==1.1.4
-Markdown==3.3.4
-MarkupSafe==1.1.1
-matplotlib @ file:///D:/bld/matplotlib-suite_1611858820206/work
+kiwisolver==1.3.2
+libclang==13.0.0
+lifelines==0.26.4
+lightgbm==3.3.2
+llvmlite==0.38.0
+locket==0.2.1
+Mako==1.1.6
+Markdown==3.3.6
+MarkupSafe==2.0.1
+matplotlib==3.5.1
+matplotlib-inline==0.1.3
 mypy-extensions==0.4.3
-networkx @ file:///home/conda/feedstock_root/build_artifacts/networkx_1598210780226/work
-numba @ file:///D:/bld/numba_1616028803047/work
-numpy==1.19.5
-oauthlib==3.1.0
-olefile @ file:///home/conda/feedstock_root/build_artifacts/olefile_1602866521163/work
+numba==0.55.1
+numpy==1.21.5
+oauthlib==3.2.0
 opt-einsum==3.3.0
-optuna==2.6.0
-packaging==20.9
-pandas @ file:///D:/bld/pandas_1614698105739/work
-parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1607618318316/work
-pathspec==0.8.1
-pbr==5.5.1
-pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1602536217715/work
-Pillow @ file:///D:/bld/pillow_1615244206091/work
-pluggy==0.13.1
-prettytable==2.1.0
-prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1616432837031/work
-protobuf==3.15.6
-py==1.10.0
+optuna==2.10.0
+packaging==21.3
+pandas==1.4.1
+parso==0.8.3
+partd==1.2.0
+pathspec==0.9.0
+pbr==5.8.1
+pickleshare==0.7.5
+Pillow==9.0.1
+pip==21.2.4
+platformdirs==2.5.0
+pluggy==1.0.0
+prettytable==3.1.0
+prompt-toolkit==3.0.28
+protobuf==3.19.4
+pure-eval==0.2.2
+py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1615243893546/work
-pyparsing==2.4.7
+Pygments==2.11.2
+pyparsing==3.0.7
 pyperclip==1.8.2
-pyreadline3==3.3
-pytest==6.2.2
-python-dateutil==2.8.1
-python-editor==1.0.4
-pytz @ file:///home/conda/feedstock_root/build_artifacts/pytz_1612179539967/work
-PyWavelets @ file:///D:/bld/pywavelets_1607290958158/work
-PyYAML==5.4.1
-regex==2021.3.17
-requests==2.25.1
-requests-oauthlib==1.3.0
-rsa==4.7.2
-scikit-image==0.16.2
-scikit-learn @ file:///D:/bld/scikit-learn_1611079981849/work
-scipy @ file:///C:/bld/scipy_1615956101586/work
-seaborn==0.11.1
-shap @ file:///D:/bld/shap_1608143581229/work
-six @ file:///home/conda/feedstock_root/build_artifacts/six_1590081179328/work
-slicer==0.0.3
-SQLAlchemy==1.4.2
-stevedore==3.3.0
-tensorboard==2.4.1
-tensorboard-plugin-wit==1.8.0
-tensorflow==2.5.1
-tensorflow-estimator==2.4.0
+pyreadline3==3.4.1
+pytest==7.0.1
+python-dateutil==2.8.2
+pytz==2021.3
+PyYAML==6.0
+requests==2.27.1
+requests-oauthlib==1.3.1
+rsa==4.8
+scikit-learn==1.0.2
+scipy==1.8.0
+seaborn==0.11.2
+setuptools==60.9.0
+shap==0.40.0
+six==1.16.0
+slicer==0.0.7
+SQLAlchemy==1.4.31
+stack-data==0.2.0
+stevedore==3.5.0
+tensorboard==2.8.0
+tensorboard-data-server==0.6.1
+tensorboard-plugin-wit==1.8.1
+tensorflow==2.8.0
+tensorflow-io-gcs-filesystem==0.24.0
 termcolor==1.1.0
-threadpoolctl @ file:///tmp/tmp79xdzxkt/threadpoolctl-2.1.0-py3-none-any.whl
-toml==0.10.2
-toolz @ file:///home/conda/feedstock_root/build_artifacts/toolz_1600973991856/work
-tornado @ file:///D:/bld/tornado_1610094858390/work
-tqdm @ file:///home/conda/feedstock_root/build_artifacts/tqdm_1614982742480/work
-traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1602771532708/work
-typed-ast==1.4.2
-typing-extensions==3.7.4.3
-urllib3==1.26.5
-wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1600965781394/work
-Werkzeug==1.0.1
+tf-estimator-nightly==2.8.0.dev2021122109
+threadpoolctl==3.1.0
+tomli==2.0.1
+toolz==0.11.2
+tqdm==4.62.3
+traitlets==5.1.1
+typing_extensions==4.1.1
+urllib3==1.26.8
+wcwidth==0.2.5
+Werkzeug==2.0.3
+wheel==0.37.1
 wincertstore==0.2
-wrapt==1.12.1
+wrapt==1.13.3


### PR DESCRIPTION
Modification to pip freeze in build_package.bat. Changes the generation of requirements.txt to only include version numbers instead of some file paths. Re-running build_package.bat also updates the requirements.txt by updating to newer package versions and changing dependencies. Passes all unit and functional tests.

Problem context and solution come from the following pip issue: pypa/pip#8174
